### PR TITLE
responsiveness fix in https://www.terredesjeunes.org/ 

### DIFF
--- a/docs/_includes/sections/h1_hero_tdj_loves.css
+++ b/docs/_includes/sections/h1_hero_tdj_loves.css
@@ -26,9 +26,22 @@
 
 @media (max-width: 1000px) {
   .my-tdj-loves-wrapper {
-    display: inline-grid;
-    justify-content: flex-start;
-    align-items: baseline;
+    display: block;
     height: 300px;
+    text-align: center;
+  }
+
+  .my-tdj-logo,
+  .my-loves {
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 5px;
+    font-size: 1.5rem;
+  }
+
+  .my-partner-icon {
+    display: block;
+    margin: 3rem auto 0 auto;
+    max-width: 300px;
   }
 }

--- a/docs/_includes/sections/h1_hero_tdj_loves.css
+++ b/docs/_includes/sections/h1_hero_tdj_loves.css
@@ -23,3 +23,12 @@
   align-items: center;
   height: 200px;
 }
+
+@media (max-width: 1000px) {
+  .my-tdj-loves-wrapper {
+    display: inline-grid;
+    justify-content: flex-start;
+    align-items: baseline;
+    height: 300px;
+  }
+}

--- a/docs/_includes/sections/syneco/metrics.html
+++ b/docs/_includes/sections/syneco/metrics.html
@@ -37,7 +37,8 @@
             (like lines, points, and axes).
             Define margins, width, and height
           */
-          const width = 1200 - margin.left - margin.right;
+          let fullWidth = window.innerWidth > 1200 ? 1200 : window.innerWidth;
+          const width = fullWidth - margin.left - margin.right;
           const height = 400 - margin.top - margin.bottom;
 
           // If displayXAxisPlotting is true to then X axis displayed in chart.

--- a/docs/_includes/sections/syneco/metrics2.html
+++ b/docs/_includes/sections/syneco/metrics2.html
@@ -36,7 +36,8 @@
             (like lines, points, and axes).
             Define margins, width, and height
           */
-          const width = 1200 - margin.left - margin.right;
+          let fullWidth = window.innerWidth > 1200 ? 1200 : window.innerWidth;
+          const width = fullWidth - margin.left - margin.right;
           const height = 400 - margin.top - margin.bottom;
 
           // If displayXAxisPlotting is true to then X axis displayed in chart.

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -2158,3 +2158,10 @@ footer {
 .mettre-activites-ici .custom-btn:hover {
   background-color: #027933;
 }
+
+.news-block-body p img {
+  height: auto;
+  max-height: 100vh;
+  max-width: 100%;
+  width: auto;
+}


### PR DESCRIPTION
In mobile view

(1) on page http://localhost:4000/a-propos/historique/

you can see full images.

(2) On pages with graphs like http://localhost:4000/synecoculture/metriques/m3/
you can see  see the whole graph

(3) on pages like https://www.terredesjeunes.org/partenaires/pcci/
 TDJ partners appears full. 

